### PR TITLE
Fix ubuntu arm64 package fetch errors

### DIFF
--- a/.github/workflows/build-pc.yml
+++ b/.github/workflows/build-pc.yml
@@ -59,10 +59,37 @@ jobs:
         run: |
           # Add ARM64 architecture first
           sudo dpkg --add-architecture arm64
+          
+          # Configure sources.list for ARM64 packages using ports.ubuntu.com
+          UBUNTU_CODENAME=$(lsb_release -cs)
+          echo "Setting up ARM64 repositories for Ubuntu $UBUNTU_CODENAME"
+          
+          # Add ARM64 repositories to sources.list
+          cat << EOF | sudo tee -a /etc/apt/sources.list
+# ARM64 repositories via ports.ubuntu.com
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $UBUNTU_CODENAME main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $UBUNTU_CODENAME-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $UBUNTU_CODENAME-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ $UBUNTU_CODENAME-backports main restricted universe multiverse
+EOF
+          
+          # Restrict existing sources to amd64 architecture to avoid conflicts
+          if [ -f /etc/apt/sources.list ]; then
+            sudo sed -i '/^deb.*ubuntu\.com/ s/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+            sudo sed -i '/^deb.*security\.ubuntu\.com/ s/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+          fi
+          
+          # Handle new DEB822 format sources if they exist
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            sudo sed -i 's/^Architectures: .*/Architectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources
+          fi
+          
           sudo apt update
+          
           # Install cross-compilation tools
           sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
             libc6-dev-arm64-cross
+            
           # Install ARM64 development libraries with retry on failure
           sudo apt install -y --fix-missing \
             libasound2-dev:arm64 \


### PR DESCRIPTION
Configure GitHub Actions to use `ports.ubuntu.com` for ARM64 packages to resolve build failures.

The ARM64 build was failing with 404 errors because the default Ubuntu repositories (`security.ubuntu.com`) do not host ARM64 packages. This PR updates the `apt` sources to correctly point to `ports.ubuntu.com`, which is the official repository for ARM64 and other non-x86 architectures, and restricts existing sources to `amd64` to prevent conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-88becd55-86fc-47c0-b0c3-3ca97959556b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88becd55-86fc-47c0-b0c3-3ca97959556b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

